### PR TITLE
轻微改动，加快截图速度

### DIFF
--- a/src/com/company/AdbCaller.java
+++ b/src/com/company/AdbCaller.java
@@ -14,11 +14,11 @@ public class AdbCaller {
 
     public static void printScreen() {
         try {
-            String prefix = "/bin/sh";
+            String prefix = "/bin/sh -c ";
             String os = System.getProperty("os.name");
             if (os.toLowerCase().startsWith("win"))
-                prefix = "cmd";
-            Process p1 = Runtime.getRuntime().exec(prefix + " /c " + Constants.ADB_PATH + " exec-out screencap -p > " + Constants.SCREENSHOT_LOCATION);
+                prefix = "cmd /c ";
+            Process p1 = Runtime.getRuntime().exec(prefix + Constants.ADB_PATH + " exec-out screencap -p > " + Constants.SCREENSHOT_LOCATION);
             p1.waitFor();
             //Process p2 = Runtime.getRuntime().exec(Constants.ADB_PATH + " pull /sdcard/screenshot.png " + Constants.SCREENSHOT_LOCATION);
             //p2.waitFor();

--- a/src/com/company/AdbCaller.java
+++ b/src/com/company/AdbCaller.java
@@ -14,8 +14,11 @@ public class AdbCaller {
 
     public static void printScreen() {
         try {
-            //需要较高版本的adb.exe，我的1.0.39没问题
-            Process p1 = Runtime.getRuntime().exec("cmd /c " + Constants.ADB_PATH + " exec-out screencap -p > " + Constants.SCREENSHOT_LOCATION);
+            String prefix = "/bin/sh";
+            String os = System.getProperty("os.name");
+            if (os.toLowerCase().startsWith("win"))
+                prefix = "cmd";
+            Process p1 = Runtime.getRuntime().exec(prefix + " /c " + Constants.ADB_PATH + " exec-out screencap -p > " + Constants.SCREENSHOT_LOCATION);
             p1.waitFor();
             //Process p2 = Runtime.getRuntime().exec(Constants.ADB_PATH + " pull /sdcard/screenshot.png " + Constants.SCREENSHOT_LOCATION);
             //p2.waitFor();

--- a/src/com/company/AdbCaller.java
+++ b/src/com/company/AdbCaller.java
@@ -14,10 +14,11 @@ public class AdbCaller {
 
     public static void printScreen() {
         try {
-            Process p1 = Runtime.getRuntime().exec(Constants.ADB_PATH + " shell screencap -p /sdcard/screenshot.png");
+            //需要较高版本的adb.exe，我的1.0.39没问题
+            Process p1 = Runtime.getRuntime().exec("cmd /c " + Constants.ADB_PATH + " exec-out screencap -p > " + Constants.SCREENSHOT_LOCATION);
             p1.waitFor();
-            Process p2 = Runtime.getRuntime().exec(Constants.ADB_PATH + " pull /sdcard/screenshot.png " + Constants.SCREENSHOT_LOCATION);
-            p2.waitFor();
+            //Process p2 = Runtime.getRuntime().exec(Constants.ADB_PATH + " pull /sdcard/screenshot.png " + Constants.SCREENSHOT_LOCATION);
+            //p2.waitFor();
         } catch (IOException e) {
             e.printStackTrace();
         } catch (InterruptedException e) {


### PR DESCRIPTION
解决思路：
使用adb exec-out来直接获取截图流
并且加入 cmd /c （linux下是/bin/sh -c）来解决java对>符的支持问题

不过，较低版本的adb不支持 exec-out 命令，我的是1.0.39没问题